### PR TITLE
Added spiral-switch-to-last-clojure-buffer

### DIFF
--- a/spiral-repl.el
+++ b/spiral-repl.el
@@ -659,6 +659,15 @@ would get automatically removed after input is sent."
           (spiral-repl--transient-text-insert group-id
                                               stdout-payload)))))))
 
+(defun spiral-switch-to-last-clojure-buffer ()
+  "Switch to the previous buffer when in spiral's REPL buffer."
+  (interactive)
+  (let ((buffers (with-current-project
+		  (spiral-project-buffers project)))
+	(not-code-buffer (lambda (buffer-name)
+			   (or (equal "*" (substring (format "%s" buffer-name) 0 1))
+			       (equal "SPIRAL" (substring (format "%s" buffer-name) 0 6))))))
+    (pop-to-buffer (first (remove-if not-code-buffer buffers)) nil t)))
 
 ;; history
 
@@ -1017,6 +1026,7 @@ inserted."
     (define-key map (kbd "C-<up>") #'spiral-repl-previous-input)
     (define-key map (kbd "C-<down>") #'spiral-repl-next-input)
     (define-key map (kbd "M-s-.") #'spiral-repl-button-goto)
+    (define-key map (kbd "C-c C-z") #'spiral-switch-to-last-clojure-buffer)
     map))
 
 (defvar spiral-repl-mode-syntax-table


### PR DESCRIPTION
As discussed in https://github.com/Unrepl/spiral/issues/11

Allow the users to switch back from from the REPL to the previous
buffer belonging to the project.

There is one issue, which I only caught when I tried to use the keybinding: intentionally the keybinding for `spiral-switch-to-last-clojure-buffer` is the same as for `spiral-switch-to-repl-buffer`. The same as in CIDER.

The only problem is that `spiral-switch-to-repl-buffer` key binding shadows `spiral-switch-to-last-clojure-buffer`. Let me fix this. But until then please let me know what you think of this function. Thanks